### PR TITLE
fix: handle no input case gracefully

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import colors from 'ansi-styles';
 // Get a list of inputs that we should hide the values of. 
 
 const listOfInputsToExclude = core.getInput('exclude_inputs').split(',').map(item => item.trim());
-let inputsObject = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')).inputs;
+let inputsObject = JSON.parse(fs.readFileSync(process.env.GITHUB_EVENT_PATH, 'utf8')).inputs || {};
 let allInputKeys = Object.keys(inputsObject);
 
 core.info(`${colors.blue.open}All inputs for this workflow: ${allInputKeys}`)


### PR DESCRIPTION
## Related GitHub Issues
N/A

## Problem
<!-- A clear description of the problem that this pull request is solving. -->
I have an action that uses either secrets or inputs and the hide sensitive info action fails when using secrets.

## Solution
<!-- Describe the approach you took to solve the problem and the changes made in this pull request. -->
Handle case where inputs are undefined.

## Testing
<!-- Choose one of the below options for how you tested the code change. Include any specific setup or instructions for testing. -->
- [ ] Added automated tests. 
- [X] Manually tested. If you check this box, provide instructions for others to test, too. 

## Notes for reviewers 
<!-- If there is any additional information you would like to share with the person reviewing this pull request, please provide it here. -->